### PR TITLE
로컬 테스트시 발생하는 문제 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
     <script src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=sx4y6v49bc&submodules=geocoder"
             type="text/javascript"></script>
-    <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=eddb65c6ffd9f693777d35d9ff66e70e&libraries=services"
+    <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=eddb65c6ffd9f693777d35d9ff66e70e&libraries=services"
             type="text/javascript"></script>
     <script src="js/dashboard.js"></script>
     <script src="js/searchPlace.js"></script>

--- a/index.html
+++ b/index.html
@@ -41,8 +41,6 @@
     <script crossorigin="anonymous"
             integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
             src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
-    <script src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=sx4y6v49bc&submodules=geocoder"
-            type="text/javascript"></script>
     <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=eddb65c6ffd9f693777d35d9ff66e70e&libraries=services"
             type="text/javascript"></script>
     <script src="js/dashboard.js"></script>


### PR DESCRIPTION
크롬에서 index.html을 로컬에서 열었을 때 아래와 같은 오류가 발생합니다.
오류로 인해 로딩 시간이 매우 길어지게 되고, 최종적으로 다음 지도가 전혀 로딩되지 않습니다.


![image](https://user-images.githubusercontent.com/38099251/58747730-3fba6e00-84aa-11e9-8014-dc97ac57c467.png)


이 PR은 위 사진에 제시된 오류를 해결합니다. (feather 관련 오류는 제외. 추후 구현 사항으로 판단되어 제외했습니다.) 따라서 이 PR을 적용하면 로컬에서 index.html을 열어 테스트가 가능합니다. 수정 과정에서 네이버 API는 사용하지 않는 것으로 판단되어 제외했습니다. 또한 README.md에 제시된 서버의 주소가 실제와 달라서 로컬 테스트에 어려움이 있었습니다. 해당 항목도 수정했습니다.