### PR TITLE
Make better responsive web design

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -12,15 +12,15 @@ body {
  * Sidebar
  */
 
- .sidebar {
+.sidebar {
   position: fixed;
   top: 0;
   left: 0;
   z-index: 100; /* Behind the navbar */
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
- }
+}
 
- @media (min-width: 992px) {
+@media (min-width: 992px) {
   .sidebar {
     display: block !important;
     bottom: 0;

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -12,16 +12,19 @@ body {
  * Sidebar
  */
 
+ .sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100; /* Behind the navbar */
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
+ }
+
  @media (min-width: 992px) {
   .sidebar {
     display: block !important;
-    position: fixed;
-    top: 0;
     bottom: 0;
-    left: 0;
-    z-index: 100; /* Behind the navbar */
     padding: 48px 0 0; /* Height of navbar */
-    box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
   }
 }
 

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -47,9 +47,11 @@ body {
 }
 
 @supports ((position: -webkit-sticky) or (position: sticky)) {
-  .sidebar-sticky {
-    position: -webkit-sticky;
-    position: sticky;
+  @media (min-width: 992px) {
+    .sidebar-sticky {
+      position: -webkit-sticky;
+      position: sticky;
+    }
   }
 }
 

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -12,23 +12,35 @@ body {
  * Sidebar
  */
 
-.sidebar {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 100; /* Behind the navbar */
-  padding: 48px 0 0; /* Height of navbar */
-  box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
+ @media (min-width: 992px) {
+  .sidebar {
+    display: block !important;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 100; /* Behind the navbar */
+    padding: 48px 0 0; /* Height of navbar */
+    box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
+  }
 }
 
-.sidebar-sticky {
-  position: relative;
-  top: 0;
-  height: calc(100vh - 48px);
-  padding-top: .5rem;
-  overflow-x: hidden;
-  overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+@media (max-width: 991px) {
+  .sidebar {
+    padding-top: 58px; /* Space for fixed navbar */
+    padding-bottom: 10px;
+  }
+}
+
+@media (min-width: 992px) {
+  .sidebar-sticky {
+    position: relative;
+    top: 0;
+    height: calc(100vh - 48px);
+    padding-top: .5rem;
+    overflow-x: auto;
+    overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+  }
 }
 
 @supports ((position: -webkit-sticky) or (position: sticky)) {
@@ -66,11 +78,7 @@ body {
  * Content
  */
 
-[role="main"] {
-  padding-top: 133px; /* Space for fixed navbar */
-}
-
-@media (min-width: 768px) {
+@media (min-width: 992px) {
   [role="main"] {
     padding-top: 48px; /* Space for fixed navbar */
   }

--- a/index.html
+++ b/index.html
@@ -55,12 +55,15 @@
 
 <body>
     <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap align-content p-0 shadow">
-        <a class="navbar-brand col-sm-3 col-md-2 mr-3 align-items-center" href="#">WhereShallWeMeet</a>
+        <a class="navbar-brand px-3" href="#">WhereShallWeMeet</a>
+        <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" data-target="#side">
+            <span class="navbar-toggler-icon"></span>
+        </button>
     </nav>
 
     <div class="container-fluid">
         <div class="row">
-            <nav class="col-md-2 d-none d-md-block bg-light sidebar">
+            <nav id="side" class="col-lg-3 bg-light sidebar collapse">
                 <div class="sidebar-sticky">
                     <!--What you want to do input form-->
                     <input aria-label="Input search query" class="form-control form-control-lg" id="whatToDo"
@@ -113,20 +116,16 @@
                     <div
                         class="sidebar-heading justify-content-between align-items-center px-3 mt-lg-4 mb-1 text-center">
                         <div aria-label="Assemble, FindRoute group" class="btn-group align-items-center" role="group">
-                            <input id="wswmBtn" class="btn btn-success btn-lg" type="button" value="Assemble!">
-                            <input id="laneBtn" class="btn btn-secondary btn-lg" type="button" value="Find Route">
+                            <input id="wswmBtn" class="btn btn-success" type="button" value="Assemble!">
+                            <input id="laneBtn" class="btn btn-secondary" type="button" value="Find Route">
                         </div>
                     </div>
                 </div>
             </nav>
 
-            <main class="col-md-10 ml-sm-auto col-lg-10 px-4" role="main">
-                <div
-                    class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                </div>
-
-                <div id="map" style="width:100%;height:900px;"></div>
-                <canvas class="my-4 w-100" height="380" id="myChart" width="900"></canvas>
+            <main class="col-lg-9 ml-sm-auto px-0" role="main" style="height: 100vh;">
+                <div id="map" style="width: 100%; height: 100%;"></div>
+                <!-- <canvas class="my-4 w-100" height="380" id="myChart" width="900"></canvas> -->
             </main>
         </div>
     </div>
@@ -134,7 +133,10 @@
         var mapContainer = document.getElementById('map'), // 지도를 표시할 div
             mapOption = {
                 center: new daum.maps.LatLng(37.504143, 126.956809), // 지도의 중심좌표
-                level: 3 // 지도의 확대 레벨
+                level: 3, // 지도의 확대 레벨
+                autosize: true,
+                offsetX: 0,
+                offsetY: 24
             };
         var map = new daum.maps.Map(mapContainer, mapOption);
         var markerList = [];


### PR DESCRIPTION
이슈 #62 와 #82 를 해결합니다. 전반적으로 어느 디스플레이 환경에서든 잘 보이게 제작했습니다.

**Before 1**
왼쪽 메뉴 레이아웃이 어긋나고 일부는 잘림. 지도 영역은 스크롤바가 생겨서 스크롤바를 내려가면서 봐야함
![w1](https://user-images.githubusercontent.com/38099251/59156174-f97c9480-8ad1-11e9-997d-d13ce9a3362f.png)

<br />

**After 1**
왼쪽 메뉴 레이아웃을 바로잡고 지도 영역은 너비와 높이에 맞게 채우도록 수정  
왼쪽 메뉴의 공간이 부족해지면 모바일 레이아웃으로 자동 전환됨
![w2](https://user-images.githubusercontent.com/38099251/59156166-e5389780-8ad1-11e9-8752-d06c939c84e5.png)

<br />

**Before 2**
작은 화면(모바일 환경 등)에서 메뉴가 나타나지 않아 이용 불가능
![w3](https://user-images.githubusercontent.com/38099251/59156181-04372980-8ad2-11e9-9490-e9d3348b6c72.png)

<br />

**After 2**
collapse 활용한 디자인으로 제작하여 정상적인 이용 가능  
우측 상단의 메뉴 버튼을 누르면 입력폼이 나타남.
![image](https://user-images.githubusercontent.com/38099251/59156308-fb475780-8ad3-11e9-8c91-916000fa7473.png)


<br />

![image](https://user-images.githubusercontent.com/38099251/59156311-026e6580-8ad4-11e9-9953-f632f42f20d3.png)

